### PR TITLE
Make keystore buildable on GHC 7.10.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ test-atlas
 benchmarks/csv
 benchmarks/chart.png
 test-state
+.stack-work

--- a/keystore.cabal
+++ b/keystore.cabal
@@ -1,5 +1,5 @@
 Name:                   keystore
-Version:                0.7.0.1
+Version:                0.8.0.0
 Synopsis:               Managing stores of secret things
 Homepage:               http://github.com/cdornan/keystore
 Author:                 Chris Dornan

--- a/src/Data/KeyStore/IO.hs
+++ b/src/Data/KeyStore/IO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
@@ -87,8 +88,11 @@ import qualified Control.Exception              as X
 import qualified Control.Lens                   as L
 import           Control.Monad
 import           System.IO
-import           System.Locale
 
+#if MIN_VERSION_time(1,5,0)
+#else
+import           System.Locale (defaultTimeLocale)
+#endif
 
 -- | Generate a new keystore located in the given file with the given global
 -- settings.

--- a/src/Data/KeyStore/PasswordManager.hs
+++ b/src/Data/KeyStore/PasswordManager.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
@@ -82,10 +83,13 @@ import qualified System.Environment                       as E
 import           System.SetEnv
 import           System.Exit
 import           System.IO
-import           System.Locale
 import qualified Options.Applicative                      as O
 import           Options.Applicative
 
+#if MIN_VERSION_time(1,5,0)
+#else
+import           System.Locale (defaultTimeLocale)
+#endif
 
 -- | The password manager is used for storing locally the passwords and session
 -- tokens of a single user.  The password used to encode the store is stored in

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,16 @@
+resolver: lts-3.7
+system-ghc: false
+install-ghc: true
+packages:
+  - '.'
+  - location:
+      git: https://github.com/iconnect/api-tools
+      commit: e1f610fd32a8c3c2299ccf6c3b19c3106e3f22d2
+  - location:
+      git: https://github.com/well-typed/binary-serialise-cbor
+      commit: 9a74b489d0015fb7b4f2b46398f316de9bc92952
+extra-deps:
+  - api-tools-0.6
+  - binary-serialize-cbor-0.1.1.0
+  - pbkdf-1.1.1.1
+  - regex-compat-tdfa-0.95.1.4


### PR DESCRIPTION
This PR makes `keystore` buildable on GHC 7.10.2.

I have added a `stack.yml` file to make this project compatible with `stack`.

You will notice I have bumped `keystore` to `0.8.0.0` and this is because it depends on 2 unreleased packages, `api-tools-0.6` and `binary-serialise-cbor`.

This means that for our purposes this will still work (as they are pulled from our private Hackage), but end users won't be able to build keystore 0.8.0.0 until both officially lands on Hackage.

I have thus bumped the version to reflect this.