### PR TITLE
0.8.1.0: fix for aeson-1.0

### DIFF
--- a/cabal.config
+++ b/cabal.config
@@ -1,0 +1,2 @@
+constraints: base>=0,
+             aeson ==1.2.1.0

--- a/examples/deploy/Deploy/Deploy.hs
+++ b/examples/deploy/Deploy/Deploy.hs
@@ -12,7 +12,6 @@ import qualified Data.ByteString.Lazy.Char8     as LBS
 import qualified Data.Text                    as T
 import qualified Data.Aeson                   as A
 import qualified Data.HashMap.Strict          as HM
-import           Control.Applicative
 
 
 deploy :: IC -> HostID -> IO LBS.ByteString

--- a/examples/deploy/Deploy/HostSectionKey.hs
+++ b/examples/deploy/Deploy/HostSectionKey.hs
@@ -14,7 +14,6 @@ import qualified Data.Text                      as T
 import qualified Data.ByteString.Char8          as B
 import qualified Data.ByteString.Lazy.Char8     as LBS
 import qualified Text.RawString.QQ              as RS
-import           Control.Monad.RWS.Strict
 import           Text.Printf
 
 

--- a/keystore.cabal
+++ b/keystore.cabal
@@ -1,5 +1,5 @@
 Name:                   keystore
-Version:                0.8.0.1
+Version:                0.8.1.0
 Synopsis:               Managing stores of secret things
 Homepage:               http://github.com/cdornan/keystore
 Author:                 Chris Dornan
@@ -164,18 +164,19 @@ Library
         Data.KeyStore.Types.PasswordStoreModel
         Data.KeyStore.Types.PasswordStoreSchema
         Data.KeyStore.Types.Schema
+        Data.KeyStore.Types.UTC
         Data.KeyStore.Version
 
     Build-depends:
-        api-tools              >= 0.4               ,
+        api-tools              >= 0.5.2             ,
         asn1-types             >= 0.2.0             ,
         asn1-encoding          >= 0.8.0             ,
         ansi-wl-pprint         >= 0.6.7             ,
         crypto-pubkey          >= 0.2.1             ,
         crypto-random          >= 0.0.7             ,
-        aeson                  >= 0.6.2             ,
+        aeson                  >= 0.8               ,
         aeson-pretty           >= 0.7               ,
-        base                   >= 4                 ,
+        base                   >= 4.8               ,
         base64-bytestring      >= 1.0               ,
         byteable               >= 0.1               ,
         bytestring             >= 0.9               ,
@@ -186,13 +187,14 @@ Library
         lens                   >= 3.9.2             ,
         mtl                    >= 2                 ,
         old-locale             >= 1.0.0.5           ,
-        optparse-applicative   >= 0.11.0   && <0.14 ,
+        optparse-applicative   >= 0.11.0            ,
         pbkdf                  >= 1.1.1.0           ,
+        regex                  >= 1.0.1.3           ,
         regex-compat-tdfa      >= 0.95.1            ,
         safe                   >= 0.3.3             ,
         setenv                 >= 0.1               ,
         text                   >= 0.11.3            ,
-        time                   >= 1.4               ,
+        time                   >= 1.5               ,
         unordered-containers   >= 0.2.3.0           ,
         vector                 >= 0.10.0.1
 
@@ -231,18 +233,18 @@ Executable deploy
     Build-depends:
         api-tools              >= 0.4               ,
         ansi-wl-pprint         >= 0.6.7.1           ,
-        aeson                  >= 0.6.2             ,
-        base                   >  4 && < 5          ,
+        aeson                  >= 0.8               ,
+        base                   >= 4.8               ,
         bytestring             >= 0.9               ,
         directory              >= 1.0               ,
         filepath               >= 1.1               ,
         keystore                                    ,
         mtl                    >= 2                 ,
-        optparse-applicative   >= 0.9.0             ,
+        optparse-applicative   >= 0.11.0            ,
         process                >= 1.2.0.0           ,
         raw-strings-qq         >= 1.0.2             ,
         setenv                 >= 0.1               ,
-        text                   >= 0.11              ,
+        text                   >= 0.11.3            ,
         unordered-containers   >= 0.2.3.0
 
     GHC-Options:

--- a/src/Data/KeyStore/CLI/Command.hs
+++ b/src/Data/KeyStore/CLI/Command.hs
@@ -15,6 +15,7 @@ module Data.KeyStore.CLI.Command
 import           Data.KeyStore.KS.Opt
 import           Data.KeyStore.Types
 import           Data.KeyStore.IO.IC
+import           Data.Monoid
 import           Data.String
 import           Text.Regex
 import qualified Data.Text              as T

--- a/src/Data/KeyStore/IO.hs
+++ b/src/Data/KeyStore/IO.hs
@@ -83,7 +83,6 @@ import qualified Data.ByteString.Base64         as B64
 import qualified Data.Map                       as Map
 import           Data.Time
 import           Text.Printf
-import           Control.Applicative
 import qualified Control.Exception              as X
 import qualified Control.Lens                   as L
 import           Control.Monad
@@ -395,7 +394,7 @@ putCtxState :: IC -> Ctx -> State -> IO ()
 putCtxState IC{..} ctx st =
  do maybe (return ()) (flip writeIORef (ctx,st)) ic_cache
     when (not $ maybe False id $ cp_readonly ic_ctx_params) $
-        LBS.writeFile (ctx_store ctx) $ keyStoreBytes $ st_keystore st
+      LBS.writeFile (ctx_store ctx) $ keyStoreBytes $ st_keystore st
 
 report :: String -> IO ()
 report = hPutStrLn stderr

--- a/src/Data/KeyStore/IO/IC.hs
+++ b/src/Data/KeyStore/IO/IC.hs
@@ -31,7 +31,6 @@ import           Data.Maybe
 import           Data.Time
 import           Data.IORef
 import qualified Control.Exception              as X
-import           Control.Applicative
 import           System.Environment
 import           System.Directory
 import           System.FilePath

--- a/src/Data/KeyStore/KS.hs
+++ b/src/Data/KeyStore/KS.hs
@@ -48,7 +48,6 @@ import           Data.Maybe
 import           Data.List
 import           Data.Time
 import           Text.Printf
-import           Control.Applicative
 import qualified Control.Lens                   as L
 import           Control.Monad
 

--- a/src/Data/KeyStore/KS/CPRNG.hs
+++ b/src/Data/KeyStore/KS/CPRNG.hs
@@ -9,7 +9,6 @@ module Data.KeyStore.KS.CPRNG
     ) where
 
 import           Crypto.Random
-import           Control.Applicative
 import qualified Data.ByteString                as B
 
 

--- a/src/Data/KeyStore/KS/Configuration.hs
+++ b/src/Data/KeyStore/KS/Configuration.hs
@@ -3,7 +3,6 @@
 module Data.KeyStore.KS.Configuration where
 
 import           Data.KeyStore.Types
-import           Data.Monoid
 import qualified Data.Map               as Map
 import           Data.Maybe
 import           Text.Regex

--- a/src/Data/KeyStore/KS/Crypto.hs
+++ b/src/Data/KeyStore/KS/Crypto.hs
@@ -55,7 +55,6 @@ import qualified Data.ASN1.BinaryEncoding       as A
 import qualified Data.ASN1.Types                as A
 import qualified Data.ByteString.Lazy.Char8     as LBS
 import qualified Data.ByteString.Char8          as B
-import           Control.Applicative
 import           Crypto.PubKey.RSA
 import qualified Crypto.PubKey.RSA.OAEP         as OAEP
 import qualified Crypto.PubKey.RSA.PSS          as PSS

--- a/src/Data/KeyStore/KS/KS.hs
+++ b/src/Data/KeyStore/KS/KS.hs
@@ -44,7 +44,6 @@ import qualified Data.Map                       as Map
 import qualified Data.ByteString                as B
 import           Data.Typeable
 import           Data.Time
-import           Control.Applicative
 import           Control.Monad.RWS.Strict
 import qualified Control.Monad.Error            as E
 import           Control.Exception

--- a/src/Data/KeyStore/KS/Opt.hs
+++ b/src/Data/KeyStore/KS/Opt.hs
@@ -41,7 +41,6 @@ import           Data.Monoid
 import           Data.Maybe
 import           Data.Char
 import           Text.Printf
-import           Control.Applicative
 
 
 data Opt a

--- a/src/Data/KeyStore/KS/Packet.hs
+++ b/src/Data/KeyStore/KS/Packet.hs
@@ -21,7 +21,6 @@ import           Data.Word
 import           Data.Bits
 import           Data.Char
 import           Text.Printf
-import           Control.Applicative
 import           Control.Monad.RWS.Strict
 import qualified Control.Monad.Error            as E
 

--- a/src/Data/KeyStore/PasswordManager.hs
+++ b/src/Data/KeyStore/PasswordManager.hs
@@ -346,7 +346,7 @@ load pmc p mb = wrap pmc $ \ps -> do
             { _ssn_name      = _sd_name
             , _ssn_password  = pwt
             , _ssn_isOneShot = ios
-            , _ssn_setup     = now
+            , _ssn_setup     = UTC now
             }
 
         ios         = _sd_isOneShot
@@ -579,7 +579,7 @@ sessions pmc a b mb = do
         pn_s = T.unpack $ _PasswordName _pw_name
         sn_s = T.unpack $ _SessionName  _ssn_name
         p_c  = if _ssn_isOneShot then prime_char False else ' '
-        su_s = pretty_setup tz _ssn_setup
+        su_s = pretty_setup tz $ _UTC _ssn_setup
         a_s  = if active_session trp then "[ACTIVE]" else "" :: String
 
     sgl = length [ () | p<-[minBound..maxBound], isJust $ isSession $ cast_pmc pmc p ] == 1

--- a/src/Data/KeyStore/Types/NameAndSafeguard.hs
+++ b/src/Data/KeyStore/Types/NameAndSafeguard.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 
 module Data.KeyStore.Types.NameAndSafeguard
     ( Name
@@ -13,14 +14,15 @@ module Data.KeyStore.Types.NameAndSafeguard
     ) where
 
 import           Data.KeyStore.Types.E
+import           Data.Char
 import qualified Data.Set                       as Set
 import           Data.String
-import           Data.Char
 import qualified Control.Exception              as X
 
 newtype Name
     = Name            { _Name            :: String       }
     deriving (Eq,Ord,IsString,Read,Show)
+
 
 name :: String -> E Name
 name s =
@@ -41,7 +43,6 @@ instance IsString Safeguard where
         case parseSafeguard s of
           Left err -> X.throw err
           Right sg -> sg
-
 
 safeguard :: [Name] -> Safeguard
 safeguard = Safeguard . Set.fromList
@@ -85,4 +86,3 @@ is_nm_char c = isAscii c || isDigit c || c `Set.member` sg_sym_chs
 
 sg_sym_chs :: Set.Set Char
 sg_sym_chs = Set.fromList ".-_:'=#$%"
-

--- a/src/Data/KeyStore/Types/PasswordStoreSchema.hs
+++ b/src/Data/KeyStore/Types/PasswordStoreSchema.hs
@@ -30,46 +30,64 @@ passwordStoreSchema    :: API
 passwordStoreChangelog :: APIChangelog
 (passwordStoreSchema, passwordStoreChangelog) = [apiWithChangelog|
 
-ps :: PasswordStore
+//
+// External Representation Only
+//
+
+// The builtin support for map-like types introduced in Aeson 1.0 has broken
+// the mechanism for representing Map in this schema. In order to minimise the
+// disruption and preserve the existing schema representation we have renamed
+// all of the types in the schema that contain Map types. In the model these
+// types are reconstructed just as they would have been in previous KeyStore
+// editions and mapping functions have been introduced to convert between the
+// two representations. The PasswordStore gets read with this representation,
+// matching the representation of past keystore packages and gets
+// converted into the internal type representation (with the maps) that the
+// rest of the keystore code base expects.
+
+z_ps :: PasswordStore_
     = record
         comment     :: PasswordStoreComment
-        map         :: PasswordMap
-        setup       :: utc
+        map         :: PasswordMap_
+        setup       :: UTC
 
-pm :: PasswordMap
+z_pm :: PasswordMap_
     // the password map, represented internally with a Map
     // from PasswordName to Password
     = record
-        map         :: [NamePasswordAssoc]
-    with inj_pwmap, prj_pwmap
+        map         :: [NamePasswordAssoc_]
 
-npa :: NamePasswordAssoc
+z_npa :: NamePasswordAssoc_
     = record
         name        :: PasswordName
-        password    :: Password
+        password    :: Password_
 
-pw  :: Password
+z_pw  :: Password_
     // passwords may be simple, or be a collection of 'sessions',
     // one of which is selected
     = record
         name        :: PasswordName
         text        :: PasswordText
-        sessions    :: SessionMap
+        sessions    :: SessionMap_
         isOneShot   :: Bool
         primed      :: boolean
-        setup       :: utc
+        setup       :: UTC
 
-smp :: SessionMap
+z_smp :: SessionMap_
     // collections of sessions are represented internally as a Map
     // from SessionName to PasswordText
     = record
-        map         :: [SessionPasswordAssoc]
-    with inj_snmap, prj_snmap
+        map         :: [SessionPasswordAssoc_]
 
-spa :: SessionPasswordAssoc
+z_spa :: SessionPasswordAssoc_
     = record
         name        :: SessionName
         session     :: Session
+
+
+//
+// Classic Schema Definitions
+//
 
 ssn :: Session
     // a session just consists of a password and the stup time
@@ -77,7 +95,7 @@ ssn :: Session
         name        :: SessionName
         password    :: PasswordText
         isOneShot   :: Bool
-        setup       :: utc
+        setup       :: UTC
 
 pwsc :: PasswordStoreComment
     // a short comment on the PasswordStore

--- a/src/Data/KeyStore/Types/UTC.hs
+++ b/src/Data/KeyStore/Types/UTC.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE QuasiQuotes                #-}
+
+module Data.KeyStore.Types.UTC (UTC(..)) where
+
+import           Data.Aeson
+import           Data.API.JSON
+import           Data.Time
+import           Text.RE.Replace
+import           Text.RE.TDFA.String
+
+
+-- | package time has some variation in the formatting of second fractions
+-- in %Q (http://hackage.haskell.org/package/time-1.8.0.2/changelog) so we
+-- we will standardise on ".xxx"
+newtype UTC = UTC { _UTC :: UTCTime }
+  deriving (Eq,Show)
+
+
+instance ToJSON UTC where
+  toJSON = toJSON . formatUTC
+
+instance FromJSON UTC where
+  parseJSON = fmap UTC . parseJSON
+
+instance FromJSONWithErrs UTC where
+  parseJSONWithErrs = fmap UTC . parseJSONWithErrs
+
+
+formatUTC :: UTC -> String
+formatUTC (UTC u) = cleanup $ formatTime defaultTimeLocale fmt u
+  where
+    fmt = iso8601DateFormat $ Just "%H:%M:%S%QZ"
+
+cleanup :: String -> String
+cleanup s = case (captureTextMaybe [cp|u|] mtch,captureTextMaybe [cp|q|] mtch) of
+    (Just u,Nothing) -> u ++ ".000Z"
+    (Just u,Just q ) -> u ++ "." ++ rjust q ++ "Z"
+    _ -> s
+  where
+    mtch = s ?=~ [re|^${u}([T0-9:-]+)(.${q}([0-9]*))?Z$|]
+
+    rjust ds = take 3 $ ds ++ "000"


### PR DESCRIPTION
This should now work with aeson-1.2.*. The support for
auto-building map instances instroduced in aeson-1.0
was interfering with the use of api-tools 'with'
constructions to achieve the same end/ To minimise the disruption
the 'with' constructions for maps were abandoned and all parts
of the schema containing maps were rebuilt with in Haskell
(without recourse to the api-tools DSL), with the old schema
renamed under renamed types. The stores are read with the
original schem to maintain identical JSON representation and
converted into the original internal format (with the maps)
using conversion functions, avoiding internal disruption.

Some adjustments in the way time formats %Q have been
eliminated by applying cleanup filter to hit the historical
format. This should ensure that existing keystore
signatures remain valid after upgrading to this keystore
without the need to re-sign.